### PR TITLE
Add SELinux context setting build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 WITH_SELINUX?=0
 ifeq ($(WITH_SELINUX), 1)
+SELINUX_CFLAGS:=-D WITH_SELINUX
 SELINUX_LDLIBS:=-lselinux
 else
+SELINUX_CFLAGS:=
 SELINUX_LDLIBS:=
 endif
 all: cc-tmpfs_mounts.so
 
 cc-tmpfs_mounts.so: cc-tmpfs_mounts.c
-	gcc $(CPPFLAGS) -std=gnu99 -Wall -o cc-tmpfs_mounts.o -fPIC -c cc-tmpfs_mounts.c -D WITH_SELINUX=$(WITH_SELINUX)
+	gcc $(CPPFLAGS) -std=gnu99 -Wall -o cc-tmpfs_mounts.o -fPIC -c cc-tmpfs_mounts.c $(SELINUX_CFLAGS)
 	gcc -shared -o cc-tmpfs_mounts.so cc-tmpfs_mounts.o $(SELINUX_LDLIBS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-
+WITH_SELINUX?=0
+ifeq ($(WITH_SELINUX), 1)
+SELINUX_LDLIBS:=-lselinux
+else
+SELINUX_LDLIBS:=
+endif
 all: cc-tmpfs_mounts.so
 
 cc-tmpfs_mounts.so: cc-tmpfs_mounts.c
-	gcc $(CPPFLAGS) -std=gnu99 -Wall -o cc-tmpfs_mounts.o -fPIC -c cc-tmpfs_mounts.c
-	gcc -shared -o cc-tmpfs_mounts.so cc-tmpfs_mounts.o 
+	gcc $(CPPFLAGS) -std=gnu99 -Wall -o cc-tmpfs_mounts.o -fPIC -c cc-tmpfs_mounts.c -D WITH_SELINUX=$(WITH_SELINUX)
+	gcc -shared -o cc-tmpfs_mounts.so cc-tmpfs_mounts.o $(SELINUX_LDLIBS)
 
 clean:
 	rm -f cc-tmpfs_mounts.o cc-tmpfs_mounts.so

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # spank-cc-tmpfs_mounts
 SPANK plugin for SLURM that allows you to create in-memory, in-cgroup private tmpfs mounts per each job of users. They will automatically clean up when the cgroup is released at the end of their job. Generally used for /tmp, /dev/shm and /var/tmp.
+
+## build options
+
+| Makefile | rpmbuild | Description | Requirements |
+| -------  | -------- | ----------- | ------------ |
+|`WITH_SELINUX=1` | `--with-selinux` | `cc-tmpfs_mount.so` plugin will try to set SELinux security context of the temporary user folders to `user_u:object_r:user_tmp_t:s0` | `libselinux-devel` |

--- a/cc-tmpfs_mounts.c
+++ b/cc-tmpfs_mounts.c
@@ -23,6 +23,11 @@
 #include <pwd.h>
 #include <ftw.h>
 
+#ifdef WITH_SELINUX
+#include <selinux/selinux.h>
+#define TMPFS_SELINUX_CONTEXT "user_u:object_r:user_tmp_t:s0"
+#endif
+
 SPANK_PLUGIN (cc-tmpfs_mounts, 1);
 
 // Default
@@ -119,6 +124,11 @@ int slurm_spank_job_prolog(spank_t sp, int ac, char **av)
             slurm_error("cc-tmpfs_mounts: mkdir(\"%s\",0750): %m", bind_target_full);
             return -1;
         }
+#ifdef WITH_SELINUX
+        if(setfilecon(bind_target_full, TMPFS_SELINUX_CONTEXT)) {
+            slurm_debug("cc-tmpfs_mounts: Unable to set %s SELinux context", bind_target_full);
+        }
+#endif
     }
     if(chown(bind_target_full,uid,gid)) {
         slurm_error("cc-tmpfs_mounts: chown(%s,%u,%u): %m", bind_target_full,uid,gid);
@@ -137,6 +147,11 @@ int slurm_spank_job_prolog(spank_t sp, int ac, char **av)
                     slurm_error("cc-tmpfs_mounts: mkdir(\"%s\",0750): %m", bind_self_full);
                     return -1;
                 }
+#ifdef WITH_SELINUX
+                if(setfilecon(bind_self_full, TMPFS_SELINUX_CONTEXT)) {
+                    slurm_debug("cc-tmpfs_mounts: Unable to set %s SELinux context", bind_self_full);
+                }
+#endif
             }
             if(chown(bind_self_full,uid,gid)) {
                 slurm_error("cc-tmpfs_mounts: chown(%s,%u,%u): %m", bind_self_full,uid,gid);

--- a/spank-cc-tmpfs_mounts.spec
+++ b/spank-cc-tmpfs_mounts.spec
@@ -14,7 +14,7 @@ BuildRequires:  slurm-devel
 Requires:       slurm-slurmd
 
 %if %{with selinux}
-BuildRequires:  selinux-devel
+BuildRequires:  libselinux-devel
 Requires:       libselinux
 %endif
 

--- a/spank-cc-tmpfs_mounts.spec
+++ b/spank-cc-tmpfs_mounts.spec
@@ -11,6 +11,10 @@ Source:         spank-cc-tmpfs_mounts-%{version}.tar.gz
 BuildRequires:  slurm-devel
 Requires:       slurm-slurmd
 
+%if %{with selinux}
+BuildRequires:  selinux-devel
+Requires:       libselinux
+%endif
 
 %global _prefix /opt/software/slurm
 %define debug_package %{nil}
@@ -20,7 +24,7 @@ Requires:       slurm-slurmd
 %setup -q
 
 %build
-CPPFLAGS="-I%{_prefix}/include" make
+CPPFLAGS="-I%{_prefix}/include" make %{?with_static:WITH_SELINUX=1}
 
 %install
 install -D -m755 cc-tmpfs_mounts.so %{buildroot}/%{_libdir}/slurm/cc-tmpfs_mounts.so

--- a/spank-cc-tmpfs_mounts.spec
+++ b/spank-cc-tmpfs_mounts.spec
@@ -1,5 +1,5 @@
 Name:           spank-cc-tmpfs_mounts
-Version:        1.2
+Version:        1.3
 Release:        1%{?dist}
 Summary:        SPANK plugin to create in-memory, in-cgroup private tmpfs mounts per each job of users.
 

--- a/spank-cc-tmpfs_mounts.spec
+++ b/spank-cc-tmpfs_mounts.spec
@@ -24,7 +24,7 @@ Requires:       libselinux
 %setup -q
 
 %build
-CPPFLAGS="-I%{_prefix}/include" make %{?with_static:WITH_SELINUX=1}
+CPPFLAGS="-I%{_prefix}/include" make %{?with_selinux:WITH_SELINUX=1}
 
 %install
 install -D -m755 cc-tmpfs_mounts.so %{buildroot}/%{_libdir}/slurm/cc-tmpfs_mounts.so

--- a/spank-cc-tmpfs_mounts.spec
+++ b/spank-cc-tmpfs_mounts.spec
@@ -8,6 +8,8 @@ License:        MIT
 URL:            https://github.com/ComputeCanada/spank-cc-tmpfs_mounts
 Source:         spank-cc-tmpfs_mounts-%{version}.tar.gz
 
+%bcond_with selinux
+
 BuildRequires:  slurm-devel
 Requires:       slurm-slurmd
 


### PR DESCRIPTION
When SELinux is activated on a cluster, the temporary folders created by the plugin inherit the SELinux label of their parent folder. In most current cases, this means `tmp_t`. Files and folders labeled as `tmp_t` cannot be read by confined users.

Slurm jobs run in an unconfined state even when SELinux is activated. The wrong labelling causes problem when the users copy files from the temporary folders to /home, /project or /scratch and try to access them from SELinux activated login node.

This PR change the file context of the temporary folder to `user_tmp_t` to make sure that confined users can properly read and write the files. The build option is entirely optional and the inability for the plugin to set the context is non-fatal.