### PR TITLE
Set XDG_RUNTIME_DIR the same as SLURM_TMPDIR

### DIFF
--- a/cc-tmpfs_mounts.c
+++ b/cc-tmpfs_mounts.c
@@ -207,6 +207,10 @@ int _tmpdir_task_init(spank_t sp, int ac, char **av)
             slurm_error("cc-tmpfs_mounts: Unable to set job's SLURM_TMPDIR env variable");
             return -1;
         }
+        if(spank_setenv(sp, "XDG_RUNTIME_DIR", bind_target_full, 1) != ESPANK_SUCCESS) {
+            slurm_error("cc-tmpfs_mounts: Unable to set job's XDG_RUNTIME_DIR env variable");
+            return -1;
+        }
         return 0;
 }
 


### PR DESCRIPTION
Slurm jobs presently inherit `XDG_RUNTIME_DIR` from the login node, set to `/run/user/<uid>`, which Slurm doesn't manage, so it typically does not exist on the compute nodes. We can however set it the same way as `SLURM_TMPDIR`, so that applications that use `XDG_RUNTIME_DIR` do not complain that that directory does not exist.